### PR TITLE
Support `extends` when parsing `tsconfig.json` file

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -68,15 +68,19 @@ function prepareCompilerOptions(cache: Map<string, CompilerOptions>, file: strin
     ?? ts.findConfigFile(file, ts.sys.fileExists);
 
   if (location) {
-    const parsed = ts.readConfigFile(location, ts.sys.readFile);
+    const { config, error } = ts.readConfigFile(location, ts.sys.readFile);
 
-    if (parsed.error) {
-      throw parsed.error;
+    if (error) {
+      throw error;
     }
 
+    const configLocation = dirname(location)
+    const { options: tsconfigOptions } = ts.parseJsonConfigFileContent(config, ts.sys, configLocation)
+
     const compilerOptions = {
-      ...parsed.config.compilerOptions,
+      ...tsconfigOptions,
       ...options?.tsconfig?.override,
+      pathsBasePath: '/Users/alexeysolovyov/CODE/GitHub/rattus-orm/attempt-3/packages/experimental-es23-decorators/src'
     } satisfies CompilerOptions;
 
     cache.set(key, compilerOptions);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -80,7 +80,6 @@ function prepareCompilerOptions(cache: Map<string, CompilerOptions>, file: strin
     const compilerOptions = {
       ...tsconfigOptions,
       ...options?.tsconfig?.override,
-      pathsBasePath: '/Users/alexeysolovyov/CODE/GitHub/rattus-orm/attempt-3/packages/experimental-es23-decorators/src'
     } satisfies CompilerOptions;
 
     cache.set(key, compilerOptions);


### PR DESCRIPTION
I discovered that if there is "extends" in tsconfig.json, like:
```
{
  "extends": "../../tsconfig.json"
}
```
then plugin does not resolve source config. It can be fixed with `ts.parseJsonConfigFileContent`.